### PR TITLE
Fix README typo and add scenario file check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The script expects the following tools to be installed and available in your `PA
 
 It also assumes several helper scripts exist in the same directory:
 
-- `database_init.sh` and `database_restor.sh` – for schema initialization or restoration.
+- `database_init.sh` and `database_restore.sh` – for schema initialization or restoration.
 - `service_start.sh` and `service_scenario_apply.sh` – for starting services and applying scenarios.
 - A scenario description file named `<usecase>.scenario.txt` describing service steps and DB update steps.
 

--- a/runpctExperimental.sh
+++ b/runpctExperimental.sh
@@ -74,6 +74,12 @@ SCENARIO_FILE="$script_dir/${USECASE}.scenario.txt"
 DEST_DIR="$script_dir/pctrun${USECASE}"
 STATIC_DIR="$DEST_DIR/staticdata"
 
+# Verify that the scenario file exists early so later steps don't fail
+if [[ ! -f $SCENARIO_FILE ]]; then
+  echo "Error: scenario file '$SCENARIO_FILE' not found." >&2
+  exit 1
+fi
+
 log_info "=== PCT Driver starting (usecase=$USECASE, adk-version=$ADK_VERSION${ADK_VERSION_SET:+ (set)}, log-level=$LOG_LEVEL) ==="
 
 # --- Step 0: Schema setup (db-provision override) ---
@@ -90,7 +96,7 @@ fi
 if [[ -n $provision_choice ]]; then
   case $provision_choice in
     1) safe_run "Init new $USECASE schema" bash -c "cd \"$script_dir\" && ./database_init.sh" ;;
-    2) safe_run "Restore $USECASE schema"   bash -c "cd \"$script_dir\" && ./database_restor.sh" ;;
+    2) safe_run "Restore $USECASE schema"   bash -c "cd \"$script_dir\" && ./database_restore.sh" ;;
     3) log_info "Using existing DB; skipping schema setup" ;;
   esac
 
@@ -101,7 +107,7 @@ elif prompt_step "0) Setup schema for '$USECASE': initialize, restore, or use ex
   read -rp "Choose [1,2 or 3]: " c
   case $c in
     1) safe_run "Init new $USECASE schema" bash -c "cd \"$script_dir\" && ./database_init.sh" ;;
-    2) safe_run "Restore $USECASE schema"   bash -c "cd \"$script_dir\" && ./database_restor.sh" ;;
+    2) safe_run "Restore $USECASE schema"   bash -c "cd \"$script_dir\" && ./database_restore.sh" ;;
     3) log_info "Assuming existing DB; skipping schema setup" ;;
     *) echo "Warning: invalid choice, skipping schema setup." >&2 ;;
   esac


### PR DESCRIPTION
## Summary
- fix helper script name in README
- check for scenario file existence in driver
- correct database restore script name

## Testing
- `bash -n runpctExperimental.sh`
- `./runpctExperimental.sh --help`
- `./runpctExperimental.sh --usecase test --skip-dbUpdate --db-provision existing --yes | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_683fe6a977b8832b9abd634b31117128