### PR TITLE
Add robust error handling and comprehensive Bats tests

### DIFF
--- a/database_init.sh
+++ b/database_init.sh
@@ -1,4 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0")" >&2
+    exit 1
+}
+
+[[ $# -eq 0 ]] || usage
+
+command -v docker >/dev/null || {
+    echo "Error: 'docker' command not found" >&2
+    exit 1
+}
+
+for f in db.env stacks/sqlserver-compose.yml; do
+    [[ -f $f ]] || { echo "Error: required file '$f' not found" >&2; exit 1; }
+done
+
 echo "Starting sql server and creating database tables"
-docker compose --env-file=db.env --profile local --profile init -f stacks/sqlserver-compose.yml up -d --force-recreate
-docker wait sqlserver.configurator
+if ! docker compose --env-file=db.env --profile local --profile init -f stacks/sqlserver-compose.yml up -d --force-recreate; then
+    echo "Error: docker compose failed" >&2
+    exit 1
+fi
+
+if ! docker wait sqlserver.configurator >/dev/null; then
+    echo "Error: sqlserver.configurator container failed" >&2
+    exit 1
+fi
+

--- a/service_scenario_apply.sh
+++ b/service_scenario_apply.sh
@@ -1,19 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-if [ -z "$1" ]
-	then
-	echo "-------------------------------------------------"
-	echo "               Apply Scenario                    "
-	echo "-------------------------------------------------"
-	echo "please provide path to scenario file as parameter"
-	exit 1
+if [[ $# -ne 1 ]]; then
+    echo "-------------------------------------------------"
+    echo "               Apply Scenario                    "
+    echo "-------------------------------------------------"
+    echo "please provide path to scenario file as parameter"
+    exit 1
 fi
 
+scenario_file="$1"
+
+if [[ ! -f $scenario_file ]]; then
+    echo "Error: scenario file '$scenario_file' not found" >&2
+    exit 1
+fi
+
+if [[ ! -s $scenario_file ]]; then
+    echo "Error: scenario file '$scenario_file' is empty" >&2
+    exit 1
+fi
+
+[[ -f helper/enable_disable_service.groovy ]] || {
+    echo "Error: helper/enable_disable_service.groovy not found" >&2
+    exit 1
+}
+
+command -v groovy >/dev/null || {
+    echo "Error: 'groovy' command not found" >&2
+    exit 1
+}
+
 services=""
+while IFS= read -r line || [[ -n $line ]]; do
+    services="${services}${services:+,}$line"
+done < "$scenario_file"
 
-while IFS= read -r line || [ -n "$line" ]; do
-	services="${services}${services:+,}$line"
-done < "$1"
+echo "applying scenario $scenario_file with enabled services $services"
+groovy helper/enable_disable_service.groovy -d stacks -m apply -s "$services"
 
-echo "applying scenario $1 with enabled services $services"
-groovy helper/enable_disable_service.groovy -d stacks -m apply -s $services

--- a/tests/database_init_test.bats
+++ b/tests/database_init_test.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+setup() {
+  setup_stubs
+  touch db.env
+  mkdir -p stacks
+  touch stacks/sqlserver-compose.yml
+}
+
+@test "database_init.sh fails without docker" {
+  run env PATH="$STUB_BIN:$PATH" bash ./database_init.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"docker"* ]]
+}
+
+@test "database_init.sh fails on container error" {
+  stub_docker_wait_fail
+  run bash ./database_init.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sqlserver.configurator"* ]]
+}
+
+@test "database_init.sh succeeds" {
+  stub_docker_success
+  run bash ./database_init.sh
+  [ "$status" -eq 0 ]
+}
+

--- a/tests/database_restore_test.bats
+++ b/tests/database_restore_test.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+setup() {
+  setup_stubs
+  touch app.env db.env
+  mkdir -p stacks
+  touch stacks/sqlserver-compose.yml
+}
+
+@test "database_restore.sh fails without docker" {
+  run env PATH="$STUB_BIN:$PATH" bash ./database_restore.sh -f /tmp -d hub -y
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"docker"* ]]
+}
+
+@test "database_restore.sh fails for missing folder" {
+  stub_docker_success
+  stub_curl_success
+  run env PATH="$STUB_BIN:$PATH" bash -c 'printf "missing\nN\nhub\n" | bash ./database_restore.sh -f missing -d hub -y'
+  [ "$status" -ne 0 ]
+}
+
+@test "database_restore.sh fails for invalid db" {
+  stub_docker_success
+  stub_curl_success
+  mkdir -p /mnt/dbbackup/default
+  touch /mnt/dbbackup/default/hub.bak
+  run env PATH="$STUB_BIN:$PATH" bash -c 'printf "default\nN\nfoo\n" | bash ./database_restore.sh -f default -d foo -y'
+  [ "$status" -ne 0 ]
+  rm -rf /mnt/dbbackup/default
+}
+
+@test "database_restore.sh succeeds" {
+  stub_docker_success
+  stub_curl_success
+  mkdir -p /mnt/dbbackup/default
+  touch /mnt/dbbackup/default/hub.bak
+  run env PATH="$STUB_BIN:$PATH" bash -c 'printf "default\nN\nhub\n" | bash ./database_restore.sh -f default -d hub -y'
+  [ "$status" -eq 0 ]
+  rm -rf /mnt/dbbackup/default
+}
+

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,0 +1,41 @@
+setup_stubs() {
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  PATH="$STUB_BIN:$PATH"
+  export STUB_BIN
+}
+
+stub_docker_success() {
+  cat <<'SH' > "$STUB_BIN/docker"
+#!/usr/bin/env bash
+if [[ $1 == wait ]]; then exit 0; fi
+exit 0
+SH
+  chmod +x "$STUB_BIN/docker"
+}
+
+stub_docker_wait_fail() {
+  cat <<'SH' > "$STUB_BIN/docker"
+#!/usr/bin/env bash
+if [[ $1 == wait ]]; then exit 1; fi
+exit 0
+SH
+  chmod +x "$STUB_BIN/docker"
+}
+
+stub_curl_success() {
+  cat <<'SH' > "$STUB_BIN/curl"
+#!/usr/bin/env bash
+cp "${@: -1}" "${@: -3:1}" # naive copy from FILE://src to dest
+SH
+  chmod +x "$STUB_BIN/curl"
+}
+
+stub_groovy_success() {
+  cat <<'SH' > "$STUB_BIN/groovy"
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$STUB_BIN/groovy"
+}
+

--- a/tests/service_scenario_apply_test.bats
+++ b/tests/service_scenario_apply_test.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+setup() {
+  setup_stubs
+  touch helper/enable_disable_service.groovy
+}
+
+@test "service_scenario_apply.sh requires argument" {
+  run bash ./service_scenario_apply.sh
+  [ "$status" -eq 1 ]
+}
+
+@test "service_scenario_apply.sh file not found" {
+  run bash ./service_scenario_apply.sh /tmp/does-not-exist
+  [ "$status" -eq 1 ]
+}
+
+@test "service_scenario_apply.sh empty file" {
+  touch empty.txt
+  run bash ./service_scenario_apply.sh empty.txt
+  [ "$status" -eq 1 ]
+  rm empty.txt
+}
+
+@test "service_scenario_apply.sh fails without groovy" {
+  echo "serviceA" > list.txt
+  run env PATH="$STUB_BIN:$PATH" bash ./service_scenario_apply.sh list.txt
+  [ "$status" -ne 0 ]
+  rm list.txt
+}
+
+@test "service_scenario_apply.sh succeeds" {
+  stub_groovy_success
+  echo "svc" > list.txt
+  run bash ./service_scenario_apply.sh list.txt
+  [ "$status" -eq 0 ]
+  rm list.txt
+}
+

--- a/tests/service_start_test.bats
+++ b/tests/service_start_test.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+setup() {
+  setup_stubs
+  stub_groovy_success
+  touch app.env
+  mkdir -p stacks
+  touch stacks/test-compose.yml
+}
+
+@test "service_start.sh requires arguments" {
+  run bash ./service_start.sh
+  [ "$status" -eq 1 ]
+}
+
+@test "service_start.sh fails without docker" {
+  run bash ./service_start.sh test
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"docker"* ]]
+}
+
+@test "service_start.sh missing compose file" {
+  stub_docker_success
+  run bash ./service_start.sh missing
+  [ "$status" -ne 0 ]
+}
+
+@test "service_start.sh succeeds" {
+  stub_docker_success
+  run bash ./service_start.sh test
+  [ "$status" -eq 0 ]
+}
+


### PR DESCRIPTION
## Summary
- tighten validations in startup scripts and ensure they exit with clear errors
- add helper utilities for stubbing commands in tests
- extend Bats suite to cover success and failure cases for each script

## Testing
- `shellcheck database_init.sh database_restore.sh service_scenario_apply.sh service_start.sh`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_6847e61aa018832bae737520bd6f8379