### PR TITLE
Fix mermaid syntax in runpct readme

### DIFF
--- a/readmePCT.md
+++ b/readmePCT.md
@@ -41,7 +41,7 @@ Below diagram summarises the major steps executed by `runpctExperimental.sh`:
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{Pre-flight checks}\n(install tools)
+    A[Start] --> B{Pre-flight checks\n(install tools)}
     B --> C[Optional env setup]
     C --> D[Step 0: Schema setup]
     D --> E[Step 1: DB update]


### PR DESCRIPTION
## Summary
- correct mermaid flowchart syntax in `readmePCT.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68551a194b88832b95edeb3537a9eae1